### PR TITLE
Revert "fix: gob encoder panic if used in alias types. (#4)"

### DIFF
--- a/hcldec/gob.go
+++ b/hcldec/gob.go
@@ -12,17 +12,15 @@ func init() {
 	// specs can be sent over gob channels, such as using
 	// github.com/hashicorp/go-plugin with plugins that need to describe
 	// what shape of configuration they are expecting.
-	// NOTE(i4k): use RegisterName() instead of Register() because the latter panics
-	// if the registered types are used in alias types.
-	gob.RegisterName("hcldec.ObjectSpec", ObjectSpec(nil))
-	gob.RegisterName("hcldec.TupleSpec", TupleSpec(nil))
-	gob.RegisterName("*hcldec.AttrSpec", (*AttrSpec)(nil))
-	gob.RegisterName("*hcldec.LiteralSpec", (*LiteralSpec)(nil))
-	gob.RegisterName("*hcldec.ExprSpec", (*ExprSpec)(nil))
-	gob.RegisterName("*hcldec.BlockSpec", (*BlockSpec)(nil))
-	gob.RegisterName("*hcldec.BlockListSpec", (*BlockListSpec)(nil))
-	gob.RegisterName("*hcldec.BlockSetSpec", (*BlockSetSpec)(nil))
-	gob.RegisterName("*hcldec.BlockMapSpec", (*BlockMapSpec)(nil))
-	gob.RegisterName("*hcldec.BlockLabelSpec", (*BlockLabelSpec)(nil))
-	gob.RegisterName("*hcldec.DefaultSpec", (*DefaultSpec)(nil))
+	gob.Register(ObjectSpec(nil))
+	gob.Register(TupleSpec(nil))
+	gob.Register((*AttrSpec)(nil))
+	gob.Register((*LiteralSpec)(nil))
+	gob.Register((*ExprSpec)(nil))
+	gob.Register((*BlockSpec)(nil))
+	gob.Register((*BlockListSpec)(nil))
+	gob.Register((*BlockSetSpec)(nil))
+	gob.Register((*BlockMapSpec)(nil))
+	gob.Register((*BlockLabelSpec)(nil))
+	gob.Register((*DefaultSpec)(nil))
 }


### PR DESCRIPTION
This reverts commit c4b87c22ef27d1f7d71f097eec7f9a59dc5dc267, reversing changes made to a2b4473778cc9443ec6f81e2c939b5e9d1b9b7fe.